### PR TITLE
feat: 动态页添加'最常访问'UP主面板

### DIFF
--- a/lib/common/api/api_constants.dart
+++ b/lib/common/api/api_constants.dart
@@ -138,6 +138,9 @@ class ApiConstants {
   static const String dynamicFeed =
       "$apiBase/x/polymer/web-dynamic/v1/feed/all";
 
+  ///动态页Up主面板
+  static const String dynamicAuthorList = "$apiBase/x/polymer/web-dynamic/v1/portal";
+
   ///点赞
   static const String like = "$apiBase/x/web-interface/archive/like";
 

--- a/lib/common/models/local/dynamic/dynamic_author.dart
+++ b/lib/common/models/local/dynamic/dynamic_author.dart
@@ -9,7 +9,8 @@ class DynamicAuthor {
       required this.officialVerify,
       required this.vip,
       required this.pubTime,
-      required this.pubAction});
+      required this.pubAction,
+      this.hasUpdate = false});
   static DynamicAuthor get zero => DynamicAuthor(
       mid: 0,
       name: "",
@@ -25,4 +26,5 @@ class DynamicAuthor {
   Vip vip;
   String pubTime;
   String pubAction;
+  bool hasUpdate;
 }

--- a/lib/common/widget/simple_easy_refresher.dart
+++ b/lib/common/widget/simple_easy_refresher.dart
@@ -9,12 +9,14 @@ class SimpleEasyRefresher extends StatefulWidget {
       required this.easyRefreshController,
       this.onLoad,
       this.onRefresh,
-      required this.childBuilder});
+      required this.childBuilder,
+      this.indicatorPosition = IndicatorPosition.above});
   final EasyRefreshController? easyRefreshController;
   final FutureOr<dynamic> Function()? onLoad;
   final FutureOr<dynamic> Function()? onRefresh;
   final Widget Function(BuildContext context, ScrollPhysics physics)?
       childBuilder;
+  final IndicatorPosition indicatorPosition;
 
   @override
   State<SimpleEasyRefresher> createState() => _SimpleEasyRefresherState();
@@ -35,12 +37,13 @@ class _SimpleEasyRefresherState extends State<SimpleEasyRefresher> {
           await widget.onRefresh?.call();
           setState(() {});
         },
-        header: const ClassicHeader(
+        header: ClassicHeader(
           hitOver: true,
           safeArea: false,
           processedDuration: Duration.zero,
           showMessage: false,
           showText: false,
+          position: widget.indicatorPosition,
           // processingText: "正在刷新...",
           // readyText: "正在刷新...",
           // armedText: "释放以刷新",
@@ -48,10 +51,11 @@ class _SimpleEasyRefresherState extends State<SimpleEasyRefresher> {
           // processedText: "刷新成功",
           // failedText: "刷新失败",
         ),
-        footer: const ClassicFooter(
+        footer: ClassicFooter(
           processedDuration: Duration.zero,
           showMessage: false,
           showText: false,
+          position: widget.indicatorPosition,
           // processingText: "加载中...",
           // processedText: "加载成功",
           // readyText: "加载中...",

--- a/lib/pages/dynamic/controller.dart
+++ b/lib/pages/dynamic/controller.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 
 import 'package:bili_you/common/api/dynamic_api.dart';
+import 'package:bili_you/common/models/local/dynamic/dynamic_author.dart';
 import 'package:bili_you/common/models/local/dynamic/dynamic_item.dart';
 import 'package:easy_refresh/easy_refresh.dart';
 import 'package:flutter/material.dart';
@@ -11,7 +12,9 @@ class DynamicController extends GetxController {
   EasyRefreshController refreshController = EasyRefreshController(
       controlFinishLoad: true, controlFinishRefresh: true);
   int currentPage = 1;
+  int authorFilterMid = -1;
   List<DynamicItem> dynamicItems = [];
+  List<DynamicAuthor> dynamicAuthorList = [];
   ScrollController scrollController = ScrollController();
   void animateToTop() {
     scrollController.animateTo(0,
@@ -21,7 +24,7 @@ class DynamicController extends GetxController {
   Future<bool> _loadDynamicItemCards() async {
     late List<DynamicItem> items;
     try {
-      items = await DynamicApi.getDynamicItems(page: currentPage);
+      items = await DynamicApi.getDynamicItems(page: currentPage, mid: authorFilterMid);
     } catch (e) {
       log("_loadDynamicItemCards:$e");
       return false;
@@ -29,6 +32,16 @@ class DynamicController extends GetxController {
     dynamicItems.addAll(items);
     if (items.isNotEmpty) {
       currentPage++;
+    }
+    return true;
+  }
+
+  Future<bool> _loadAuthorList() async {
+    try {
+      dynamicAuthorList = await DynamicApi.getDynamicAuthorList();
+    } catch (e) {
+      log("_loadDynamicAuthorList:$e");
+      return false;
     }
     return true;
   }
@@ -44,10 +57,19 @@ class DynamicController extends GetxController {
   void onRefresh() async {
     dynamicItems.clear();
     currentPage = 1;
+    if (authorFilterMid == -1) {
+      await _loadAuthorList();
+      authorFilterMid = 0;
+    }
     if (await _loadDynamicItemCards()) {
       refreshController.finishRefresh(IndicatorResult.success);
     } else {
       refreshController.finishRefresh(IndicatorResult.fail);
     }
+  }
+
+  void applyAuthorFilter(mid) {
+    authorFilterMid = mid;
+    refreshController.callRefresh();
   }
 }

--- a/lib/pages/dynamic/view.dart
+++ b/lib/pages/dynamic/view.dart
@@ -1,5 +1,7 @@
 import 'package:bili_you/common/widget/simple_easy_refresher.dart';
+import 'package:bili_you/pages/dynamic/widget/dynamic_author_filter.dart';
 import 'package:bili_you/pages/dynamic/widget/dynamic_item_card.dart';
+import 'package:easy_refresh/easy_refresh.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -32,13 +34,24 @@ class _DynamicPageState extends State<DynamicPage> {
         appBar: AppBar(title: const Text("动态")),
         body: SimpleEasyRefresher(
           easyRefreshController: controller.refreshController,
-          childBuilder: (context, physics) => ListView.builder(
+          indicatorPosition: IndicatorPosition.locator,
+          childBuilder: (context, physics) => CustomScrollView(
             cacheExtent: MediaQuery.of(context).size.height,
             controller: controller.scrollController,
             physics: physics,
-            itemCount: controller.dynamicItems.length,
-            itemBuilder: (context, index) =>
-                DynamicItemCard(dynamicItem: controller.dynamicItems[index]),
+            slivers: [
+              DynamicAuthorFilter(
+                authors: controller.dynamicAuthorList,
+                onAuthorFilterApplied: controller.applyAuthorFilter,
+              ),
+              const HeaderLocator.sliver(),
+              SliverList.builder(
+                itemCount: controller.dynamicItems.length,
+                itemBuilder: (context, index) =>
+                    DynamicItemCard(dynamicItem: controller.dynamicItems[index]),
+              ),
+              const FooterLocator.sliver(),
+            ],
           ),
           onLoad: controller.onLoad,
           onRefresh: controller.onRefresh,

--- a/lib/pages/dynamic/widget/dynamic_author_filter.dart
+++ b/lib/pages/dynamic/widget/dynamic_author_filter.dart
@@ -1,0 +1,108 @@
+import 'package:bili_you/common/models/local/dynamic/dynamic_author.dart';
+import 'package:bili_you/common/widget/avatar.dart';
+import 'package:flutter/material.dart';
+
+class DynamicAuthorFilter extends StatefulWidget {
+  const DynamicAuthorFilter({super.key, required this.authors, this.onAuthorFilterApplied, this.height = 85, this.iconSize = 55});
+
+  final double height;
+  final double iconSize;
+  final List<DynamicAuthor> authors;
+  final void Function(int mid)? onAuthorFilterApplied;
+
+  @override
+  State<StatefulWidget> createState() => _DynamicAuthorFilter();
+}
+
+class _DynamicAuthorFilter extends State<DynamicAuthorFilter> {
+  static const itemPadding = EdgeInsets.symmetric(horizontal: 10, vertical: 5);
+  final itemScrollController = ScrollController();
+  int filterMid = 0;
+
+  GestureTapCallback buildOnItemTapCallback(int index, DynamicAuthor author) {
+    return () {
+      if (filterMid == author.mid) {
+        filterMid = 0;
+      } else {
+        filterMid = author.mid;
+        author.hasUpdate = false;
+        itemScrollController.animateTo((index + 0.5) * (widget.iconSize + itemPadding.horizontal) - (0.5 * MediaQuery.of(context).size.width),
+            duration: const Duration(milliseconds: 200), curve: Curves.linear);
+      }
+      setState(() {});
+      widget.onAuthorFilterApplied?.call(filterMid);
+    };
+  }
+
+  Widget buildAuthorListItem(int index, DynamicAuthor author) {
+    return InkWell(
+        onTap: buildOnItemTapCallback(index, author),
+        child: Padding(
+            padding: itemPadding,
+            child: Opacity(
+                opacity: filterMid == 0 || filterMid == author.mid ? 1.0 : 0.3,
+                child: Column(mainAxisSize: MainAxisSize.min, children: [
+                  Badge(
+                      smallSize: 8,
+                      alignment: AlignmentDirectional.bottomEnd,
+                      isLabelVisible: author.hasUpdate,
+                      child: AvatarWidget(
+                        avatarUrl: author.avatarUrl,
+                        radius: widget.iconSize / 2,
+                      )),
+                  Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: SizedBox(
+                          width: widget.iconSize,
+                          child: Text(
+                            author.name,
+                            overflow: TextOverflow.fade,
+                            softWrap: false,
+                            textAlign: TextAlign.center,
+                            style: TextStyle(color: Theme.of(context).hintColor, fontSize: 12),
+                          ))),
+                ]))));
+  }
+
+  Widget buildAuthorList(BuildContext context) {
+    return Container(
+        height: widget.height,
+        color: Theme.of(context).cardColor,
+        child: ListView.builder(
+          scrollDirection: Axis.horizontal,
+          controller: itemScrollController,
+          itemCount: widget.authors.length,
+          itemBuilder: (context, index) => buildAuthorListItem(index, widget.authors[index]),
+        ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverPersistentHeader(
+      floating: true,
+      pinned: false,
+      delegate: _SliverHeaderDelegate(height: widget.height, child: buildAuthorList(context)),
+    );
+  }
+}
+
+class _SliverHeaderDelegate extends SliverPersistentHeaderDelegate {
+  _SliverHeaderDelegate({required this.height, required this.child});
+
+  final double height;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return child;
+  }
+
+  @override
+  double get maxExtent => height;
+
+  @override
+  double get minExtent => height;
+
+  @override
+  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) => true;
+}


### PR DESCRIPTION
给动态页加一个浮动的'最常访问 Up 主'栏，点击过滤出某个 Up 的动态，再点一次取消过滤，效果类似 YouTube。

具体改动：
- API: 添加一个 API 调用，用来获取动态页的 Up 列表；修改`_requestDynamic()`获取动态的方法，获取特定`mid`的动态。
- Model: 修改`DynamicAuthor`，加一个字段表示是否有未阅读的动态更新。
- Widget: 加一个`SliverPersistentHeader`，用来放横向滚动的 Up 列表。
- Widget: 修改`SimpleEasyRefresher`，允许定义刷新 Indicator 的位置，防止动态列表跟 Up 列表放在一个`CustomScrollView`时刷新箭头被遮挡。
- View&Controller: 加上获取 Up 列表和动态过滤的 UI 和逻辑。