### PR TITLE
改进播放器手势

### DIFF
--- a/lib/pages/bili_video/widgets/bili_video_player/bili_video_player_panel.dart
+++ b/lib/pages/bili_video/widgets/bili_video_player/bili_video_player_panel.dart
@@ -206,9 +206,8 @@ class _BiliVideoPlayerPanelState extends State<BiliVideoPlayerPanel> {
             if (!isHorizontalGestureInProgress) {
               return;
             }
-            double scale = 0.5 / 1000;
-            Duration pos = widget.controller._position +
-                widget.controller._duration * details.delta.dx * scale;
+            double scale = 60000 / MediaQuery.of(context).size.width;
+            Duration pos = widget.controller._position + Duration(milliseconds: (details.delta.dx * scale).round());
             widget.controller._position = Duration(
                 milliseconds: pos.inMilliseconds
                     .clamp(0, widget.controller._duration.inMilliseconds));


### PR DESCRIPTION
改进了一下播放器手势的一些细节。

- 增加边缘的死区，与 Bilibili App 类似，忽略从边缘开始的左右和上下滑动手势。防止手势会跟系统的手势冲突。
- 左右滑动手势控制进度条使用固定幅度。现在左右滑动调整的时长跟视频时长有关，这样在遇到长视频时会变得很敏感。这里改成跟 Bilibili App 一样的固定幅度，一个屏幕左右跨度为一分钟。
